### PR TITLE
chore: update readme to change `service` to `services` when starting redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew services start postgresql
 brew install redis
 
 # start redis service
-brew service start redis
+brew services start redis
 ```
 
 Setup database


### PR DESCRIPTION
This PR update the reamde and rename `brew service start redis` to `brew services start redis`