### PR TITLE
Add nonce generation for encrypting order recipient details

### DIFF
--- a/controllers/accounts/profile_test.go
+++ b/controllers/accounts/profile_test.go
@@ -420,14 +420,14 @@ func TestProfile(t *testing.T) {
 			}
 			t.Run("fails for invalid mobile number", func(t *testing.T) {
 				payload := types.ProviderProfilePayload{
-					MobileNumber:   "1234567890",
+					MobileNumber:   "01234567890",
 					TradingName:    testCtx.providerProfile.TradingName,
 					HostIdentifier: testCtx.providerProfile.HostIdentifier,
 					Currency:       "KES",
 				}
 				res1 := profileUpdateRequest(payload)
 
-				payload.MobileNumber = "+23456789029"
+				payload.MobileNumber = "+023456789029"
 				res2 := profileUpdateRequest(payload)
 
 				// Assert the response body

--- a/controllers/accounts/profile_test.go
+++ b/controllers/accounts/profile_test.go
@@ -444,6 +444,33 @@ func TestProfile(t *testing.T) {
 				assert.Equal(t, "Invalid mobile number", response.Message)
 			})
 
+			t.Run("success for valid moblie number", func(t *testing.T) {
+				payload := types.ProviderProfilePayload{
+					MobileNumber:   "+2347012345678",
+					TradingName:    testCtx.providerProfile.TradingName,
+					HostIdentifier: testCtx.providerProfile.HostIdentifier,
+					Currency:       "KES",
+				}
+				res := profileUpdateRequest(payload)
+
+				// Assert the response body
+				assert.Equal(t, http.StatusOK, res.Code)
+
+				var response types.Response
+				err = json.Unmarshal(res.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, "Profile updated successfully", response.Message)
+
+				// Assert optional fields were correctly set and retrieved
+				providerProfile, err := db.Client.ProviderProfile.
+					Query().
+					Where(providerprofile.HasUserWith(user.ID(testCtx.user.ID))).
+					Only(context.Background())
+				assert.NoError(t, err)
+
+				assert.Equal(t, providerProfile.MobileNumber, "+2347012345678")
+			})
+
 			t.Run("fails for invalid identity document type", func(t *testing.T) {
 				payload := types.ProviderProfilePayload{
 					IdentityDocumentType: "student_id",

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -1506,33 +1506,11 @@ func (s *IndexerService) getOrderRecipientFromMessageHash(messageHash string) (*
 		return nil, err
 	}
 
-	// Attempt to unmarshal the message with nonce
-    var messageWithNonce struct {
-        Nonce             string
-        AccountIdentifier string
-        AccountName       string
-        Institution       string
-        ProviderID        string
-        Memo              string
-    }
-
-	if err := json.Unmarshal(messageBytes, &messageWithNonce); err == nil {
-        // Successfully unmarshaled message with nonce
-        return &types.PaymentOrderRecipient{
-            AccountIdentifier: messageWithNonce.AccountIdentifier,
-            AccountName:       messageWithNonce.AccountName,
-            Institution:       messageWithNonce.Institution,
-            ProviderID:        messageWithNonce.ProviderID,
-            Memo:              messageWithNonce.Memo,
-        }, nil
-    } else {
-		var recipient *types.PaymentOrderRecipient
-		if err := json.Unmarshal(messageBytes, &recipient); err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-		return recipient, nil
+	var recipient *types.PaymentOrderRecipient
+	err = json.Unmarshal(messageBytes, &recipient); if err != nil {
+		return nil, fmt.Errorf("%w", err)
 	}
-	
+	return recipient, nil
 }
 
 // UpdateReceiveAddressStatus updates the status of a receive address. if `done` is true, the indexing process is complete for the given receive address

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -1506,12 +1506,33 @@ func (s *IndexerService) getOrderRecipientFromMessageHash(messageHash string) (*
 		return nil, err
 	}
 
-	var recipient *types.PaymentOrderRecipient
-	if err := json.Unmarshal(messageBytes, &recipient); err != nil {
-		return nil, fmt.Errorf("%w", err)
-	}
+	// Attempt to unmarshal the message with nonce
+    var messageWithNonce struct {
+        Nonce             string
+        AccountIdentifier string
+        AccountName       string
+        Institution       string
+        ProviderID        string
+        Memo              string
+    }
 
-	return recipient, nil
+	if err := json.Unmarshal(messageBytes, &messageWithNonce); err == nil {
+        // Successfully unmarshaled message with nonce
+        return &types.PaymentOrderRecipient{
+            AccountIdentifier: messageWithNonce.AccountIdentifier,
+            AccountName:       messageWithNonce.AccountName,
+            Institution:       messageWithNonce.Institution,
+            ProviderID:        messageWithNonce.ProviderID,
+            Memo:              messageWithNonce.Memo,
+        }, nil
+    } else {
+		var recipient *types.PaymentOrderRecipient
+		if err := json.Unmarshal(messageBytes, &recipient); err != nil {
+			return nil, fmt.Errorf("%w", err)
+		}
+		return recipient, nil
+	}
+	
 }
 
 // UpdateReceiveAddressStatus updates the status of a receive address. if `done` is true, the indexing process is complete for the given receive address

--- a/services/order/evm.go
+++ b/services/order/evm.go
@@ -2,6 +2,7 @@ package order
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -816,14 +817,20 @@ func (s *OrderEVM) settleCallData(ctx context.Context, order *ent.LockPaymentOrd
 
 // encryptOrderRecipient encrypts the recipient details
 func (s *OrderEVM) encryptOrderRecipient(recipient *ent.PaymentOrderRecipient) (string, error) {
+	// Generate a cryptographically secure random nonce
+    nonce := make([]byte, 32)
+    if _, err := rand.Read(nonce); err != nil {
+        return "", fmt.Errorf("failed to generate nonce: %w", err)
+    }
 	message := struct {
+		Nonce			  string
 		AccountIdentifier string
 		AccountName       string
 		Institution       string
 		ProviderID        string
 		Memo              string
 	}{
-		recipient.AccountIdentifier, recipient.AccountName, recipient.Institution, recipient.ProviderID, recipient.Memo,
+		base64.StdEncoding.EncodeToString(nonce), recipient.AccountIdentifier, recipient.AccountName, recipient.Institution, recipient.ProviderID, recipient.Memo,
 	}
 
 	// Encrypt with the public key of the aggregator

--- a/services/order/tron.go
+++ b/services/order/tron.go
@@ -3,6 +3,7 @@ package order
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -644,14 +645,20 @@ func (s *OrderTron) settleCallData(ctx context.Context, order *ent.LockPaymentOr
 
 // encryptOrderRecipient encrypts the recipient details
 func (s *OrderTron) encryptOrderRecipient(recipient *ent.PaymentOrderRecipient) (string, error) {
+	// Generate a cryptographically secure random nonce
+    nonce := make([]byte, 32)
+    if _, err := rand.Read(nonce); err != nil {
+        return "", fmt.Errorf("failed to generate nonce: %w", err)
+    }
 	message := struct {
+		Nonce			  string
 		AccountIdentifier string
 		AccountName       string
 		Institution       string
 		ProviderID        string
 		Memo              string
 	}{
-		recipient.AccountIdentifier, recipient.AccountName, recipient.Institution, recipient.ProviderID, recipient.Memo,
+		base64.StdEncoding.EncodeToString(nonce), recipient.AccountIdentifier, recipient.AccountName, recipient.Institution, recipient.ProviderID, recipient.Memo,
 	}
 
 	// Encrypt with the public key of the aggregator

--- a/types/types.go
+++ b/types/types.go
@@ -387,6 +387,7 @@ type PaymentOrderRecipient struct {
 	Memo              string `json:"memo" binding:"required"`
 	ProviderID        string `json:"providerId"`
 	Currency          string `json:"currency"`
+	Nonce 		      string `json:"nonce"`
 }
 
 // NewPaymentOrderPayload is the payload for the create payment order endpoint


### PR DESCRIPTION
Introduce nonce generation to enhance the security of order recipient details during encryption. This change allows for the inclusion of a nonce in the encrypted message, improving data integrity and security.

closes #370