### PR TITLE
Update SendUserOperation to use eth_getUserOperationReceipt

### DIFF
--- a/services/indexer.go
+++ b/services/indexer.go
@@ -879,41 +879,6 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 		return nil
 	}
 
-	go func() {
-		timeToWait := 2 * time.Second
-
-		time.Sleep(timeToWait)
-		_ = utils.Retry(10, timeToWait, func() error {
-			// Update payment order with the gateway ID
-			paymentOrder, err := db.Client.PaymentOrder.
-				Query().
-				Where(
-					paymentorder.TxHashEQ(event.TxHash),
-				).
-				Only(ctx)
-			if err != nil {
-				if ent.IsNotFound(err) {
-					// Payment order does not exist, retry
-					return fmt.Errorf("trigger retry")
-				} else {
-					return fmt.Errorf("CreateLockPaymentOrder.db: %v", err)
-				}
-			}
-
-			_, err = db.Client.PaymentOrder.
-				Update().
-				Where(paymentorder.IDEQ(paymentOrder.ID)).
-				SetBlockNumber(int64(event.BlockNumber)).
-				SetGatewayID(gatewayId).
-				Save(ctx)
-			if err != nil {
-				return fmt.Errorf("CreateLockPaymentOrder.db: %v", err)
-			}
-
-			return nil
-		})
-	}()
-
 	// Get token from db
 	token, err := db.Client.Token.
 		Query().

--- a/services/order/evm.go
+++ b/services/order/evm.go
@@ -147,7 +147,7 @@ func (s *OrderEVM) CreateOrder(ctx context.Context, client types.RPCClient, orde
 	}
 
 	// Send user operation
-	txHash, blockNumber, err := utils.SendUserOperation(userOperation, order.Edges.Token.Edges.Network.ChainID)
+	txHash, gatewayOrderId, blockNumber, err := utils.SendUserOperation(userOperation, order.Edges.Token.Edges.Network.ChainID)
 	if err != nil {
 		return fmt.Errorf("%s - CreateOrder.SendUserOperation: %w", orderIDPrefix, err)
 	}
@@ -156,6 +156,7 @@ func (s *OrderEVM) CreateOrder(ctx context.Context, client types.RPCClient, orde
 	_, err = order.Update().
 		SetTxHash(txHash).
 		SetBlockNumber(blockNumber).
+		SetGatewayID(gatewayOrderId).
 		SetRate(order.Rate).
 		SetStatus(paymentorder.StatusPending).
 		Save(ctx)
@@ -228,7 +229,7 @@ func (s *OrderEVM) RefundOrder(ctx context.Context, client types.RPCClient, orde
 	_ = utils.SignUserOperation(userOperation, lockOrder.Edges.Token.Edges.Network.ChainID)
 
 	// Send user operation
-	txHash, blockNumber, err := utils.SendUserOperation(userOperation, lockOrder.Edges.Token.Edges.Network.ChainID)
+	txHash, _, blockNumber, err := utils.SendUserOperation(userOperation, lockOrder.Edges.Token.Edges.Network.ChainID)
 	if err != nil {
 		return fmt.Errorf("%s - RefundOrder.sendUserOperation: %w", orderIDPrefix, err)
 	}
@@ -303,7 +304,7 @@ func (s *OrderEVM) SettleOrder(ctx context.Context, client types.RPCClient, orde
 	_ = utils.SignUserOperation(userOperation, order.Edges.Token.Edges.Network.ChainID)
 
 	// Send user operation
-	txHash, blockNumber, err := utils.SendUserOperation(userOperation, order.Edges.Token.Edges.Network.ChainID)
+	txHash, _, blockNumber, err := utils.SendUserOperation(userOperation, order.Edges.Token.Edges.Network.ChainID)
 	if err != nil {
 		return fmt.Errorf("%s - SettleOrder.sendUserOperation: %w", orderIDPrefix, err)
 	}

--- a/services/order/evm.go
+++ b/services/order/evm.go
@@ -164,16 +164,6 @@ func (s *OrderEVM) CreateOrder(ctx context.Context, client types.RPCClient, orde
 		return fmt.Errorf("%s - CreateOrder.updateTxHash: %w", orderIDPrefix, err)
 	}
 
-	_, err = db.Client.PaymentOrder.
-		Update().
-		Where(paymentorder.IDEQ(orderID)).
-		SetBlockNumber(blockNumber).
-		SetGatewayID(gatewayOrderId).
-		Save(ctx)
-	if err != nil {
-		return fmt.Errorf("CreateLockPaymentOrder.db: %v", err)
-	}
-
 	// Refetch payment order
 	paymentOrder, err := db.Client.PaymentOrder.
 		Query().

--- a/services/order/evm.go
+++ b/services/order/evm.go
@@ -164,6 +164,16 @@ func (s *OrderEVM) CreateOrder(ctx context.Context, client types.RPCClient, orde
 		return fmt.Errorf("%s - CreateOrder.updateTxHash: %w", orderIDPrefix, err)
 	}
 
+	_, err = db.Client.PaymentOrder.
+		Update().
+		Where(paymentorder.IDEQ(orderID)).
+		SetBlockNumber(blockNumber).
+		SetGatewayID(gatewayOrderId).
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("CreateLockPaymentOrder.db: %v", err)
+	}
+
 	// Refetch payment order
 	paymentOrder, err := db.Client.PaymentOrder.
 		Query().

--- a/utils/userop.go
+++ b/utils/userop.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/big"
 	"strings"
 	"time"

--- a/utils/userop_test.go
+++ b/utils/userop_test.go
@@ -113,8 +113,8 @@ func TestUserOp(t *testing.T) {
 						},
 					},
 				})
-					log.Printf("Mock Data: %+v\n", resp)
-					return resp, err
+				
+				return resp, err
 				}
 
 				return httpmock.NewBytesResponse(200, []byte(`{"jsonrpc": "2.0","id": 1,"result":[]}`)), nil

--- a/utils/userop_test.go
+++ b/utils/userop_test.go
@@ -73,15 +73,47 @@ func TestUserOp(t *testing.T) {
 						"result":  "0xa12db69d8d43384e9d9da5f0e9b9698c97c9a90c3447aa815d3f28daf21d3834",
 					})
 					return resp, err
-				} else if strings.Contains(string(bytes), "eth_getUserOperationByHash") {
+				} else if strings.Contains(string(bytes), "eth_getUserOperationReceipt") {
 					resp, err := httpmock.NewJsonResponse(200, map[string]interface{}{
-						"jsonrpc": "2.0",
-						"id":      1,
-						"result": map[string]interface{}{
-							"transactionHash": "0xa12db69d8d43384e9d9da5f0e9b9698c97c9a90c3447aa815d3f28daf21d3834",
-							"blockNumber":     120,
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result": map[string]interface{}{
+						"logs": []interface{}{
+								map[string]interface{}{
+									"topics": []interface{}{
+										"0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f",
+										"0x15178e60f1185869b7001608bc4f57ebd9064b77c7f8cc08db1da75464b535b3",
+										"0x000000000000000000000000500081e858f7a214cfe4f729f0321ee0e24f900f",
+										"0x00000000000000000000000000000f79b7faf42eebadba19acc07cd08af44789",
+									},
+									"blockNumber": "0x3494a41",
+									"transactionHash": "0xd4c6ca8929833176505e4a1ee5693a5f5116415414ab672d0949bbd82df4ff54",
+								},
+							},
+						"receipt": map[string]interface{}{
+							"blockNumber":       "0x3494a41",
+							"logs": []interface{}{
+								map[string]interface{}{
+									"address": "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789",
+									"topics": []interface{}{
+										"0x40ccd1ceb111a3c186ef9911e1b876dc1f789ed331b86097b3b8851055b6a137",
+									},
+									"data":             "000000000000000000000000000000000000000000000000000000000000235a71dd0fb221e509dd357a139d634d109422bd2d105c555754afc840ce9f08c8a100000000000000000000000000000000000000000000000000000000000006a30000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000015857716a554b69537231374e4469777449422b486a68365237357371796557577144324b462f4641367338505a4370484e6d5857534e464d6644754b6649676f7a424978414762685862376f6c6d5463367264427575774f654163594c4e4d45564c396465385047582f654c2f796d7a6d50796a6a393535354879625538675949453062337a4c445a64474d314e7a3465557530576e4a2b494946357353424c373678506d5431726b4546797463505a2f666f44534f7368326b7973466879526b634e3356365a717832716957733938484362757a724358614f2b445a634e6836666e492f2b66506f4b35674e74384e684e77714b703830376c354131347755396d6a53625a376978594278324473516f69576677474e616b6559505745445269514d36547a766f33727750442f4d54304c75784b2f472f6556785a7a574c2b74324847336846746748476958745161366f51477363413d3d0000000000000000",
+									"blockNumber":      "0x3494a41",
+									"transactionHash":  "0xd4c6ca8929833176505e4a1ee5693a5f5116415414ab672d0949bbd82df4ff54",
+									"transactionIndex": "0x68",
+									"blockHash":        "0x93412643414b664e4fd3467ff58c3bcbd6dc83b84080e1f044e7a16fcf015806",
+								},
+							},
+							"logsBloom":         "0x000000000000010000000000000000000000000000000000000000000000020000090000000000040002001100400000001081000000000000000200000000000000000000000000000000280000008000080000000020000001000000000000000000000a000000000000000000280000000000080000408080001000080000004008000004000000000000000000020000000000000000000000000000000020000000000400000050...",
+							"status":            "0x1",
+							"to":                "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789",
+							"transactionIndex":  "0x68",
+							"type":              "0x2",
 						},
-					})
+					},
+				})
+					log.Printf("Mock Data: %+v\n", resp)
 					return resp, err
 				}
 
@@ -89,10 +121,10 @@ func TestUserOp(t *testing.T) {
 
 			},
 		)
-		transactionHash, blockNumber, err := SendUserOperation(data, 1)
+		transactionHash, _, blockNumber, err := SendUserOperation(data, 1)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, transactionHash, "transactionHash should not be empty")
-		assert.Equal(t, int64(120), blockNumber)
+		assert.Equal(t, int64(55134785), blockNumber)
 
 	})
 


### PR DESCRIPTION
Replace the use of `eth_getUserOperationByHash` with `eth_getUserOperationReceipt` in the SendUserOperation function to return the order ID along with the transaction hash and block number. Adjusting related functions and tests accordingly.

closes #369