### PR TITLE
Add New Fiat Currencies (BRL, USD, ZAR, INR) with Their Institutions

### DIFF
--- a/ent/migrate/migrations/20250117082336_add_fiat_currencies_2.sql
+++ b/ent/migrate/migrations/20250117082336_add_fiat_currencies_2.sql
@@ -1,0 +1,23 @@
+INSERT INTO fiat_currencies (
+    id, code, short_name, decimals, symbol, name, market_rate, is_enabled, created_at, updated_at
+) VALUES (
+    gen_random_uuid(), 'BRL', 'BRL', 2, 'R$', 'Brazilian Real', 6.222336, false, now(), now()
+);
+
+INSERT INTO fiat_currencies (
+    id, code, short_name, decimals, symbol, name, market_rate, is_enabled, created_at, updated_at
+) VALUES (
+    gen_random_uuid(), 'USD', 'USD', 2, '$', 'United States Dollar', 1.027908, false, now(), now()
+);
+
+INSERT INTO fiat_currencies (
+    id, code, short_name, decimals, symbol, name, market_rate, is_enabled, created_at, updated_at
+) VALUES (
+    gen_random_uuid(), 'ZAR', 'ZAR', 2, 'R', 'South African Rand', 19.330148, false, now(), now()
+);
+
+INSERT INTO fiat_currencies (
+    id, code, short_name, decimals, symbol, name, market_rate, is_enabled, created_at, updated_at
+) VALUES (
+    gen_random_uuid(), 'INR', 'INR', 2, '₹', 'Indian Rupee', 89.031731, false, now(), now()
+);

--- a/ent/migrate/migrations/20250117085340_inr_institutions.sql
+++ b/ent/migrate/migrations/20250117085340_inr_institutions.sql
@@ -1,0 +1,47 @@
+-- First, check if the INR fiat currency exists
+SELECT EXISTS (
+    SELECT 1 FROM "fiat_currencies"
+    WHERE "code" = 'INR'
+);
+
+-- If the INR fiat currency exists, then add the institutions
+DO $$
+DECLARE
+    fiat_currency_id UUID;
+    last_bucket_id BIGINT;
+BEGIN
+    -- Get the ID of the INR fiat currency
+    SELECT "id" INTO fiat_currency_id
+    FROM "fiat_currencies"
+    WHERE "code" = 'INR';
+
+    -- Add institutions to the INR fiat currency
+    WITH institutions (code, name, type, updated_at, created_at) AS (
+        VALUES
+            ('ACBLINBB', 'Abhyudaya Cooperative Bank Limited', 'bank', now(), now()),
+            ('APBLINPC', 'Airtel Payments Bank Limited', 'bank', now(), now()),
+            ('ANDBINBB', 'Andhra Pragathi Grameena Bank', 'bank', now(), now()),
+            ('AUBLINBB', 'Au Small Finance Bank Limited', 'bank', now(), now()),
+            ('ANZBINBX', 'Australia And New Zealand Banking Group Limited', 'bank', now(), now()),
+            ('BARBINBB', 'Bank Of Baroda', 'bank', now(), now()),
+            ('BSSEINBB', 'Bassein Catholic Cooperative Bank Limited', 'bank', now(), now()),
+            ('CITIINBX', 'Citi Bank', 'bank', now(), now()),
+            ('HDFCINBB', 'Hdfc Bank', 'bank', now(), now())
+          
+    )
+    INSERT INTO "institutions" ("code", "name", "fiat_currency_institutions", "type", "updated_at", "created_at")
+    SELECT "code", "name", fiat_currency_id, "type", "updated_at", "created_at"
+    FROM institutions
+    ON CONFLICT ("code") DO NOTHING;
+
+    -- Get the last bucket ID
+    SELECT COALESCE(MAX(id), 0) INTO last_bucket_id FROM provision_buckets;
+
+    -- Add provision buckets to the INR fiat currency
+    INSERT INTO provision_buckets (id, min_amount, max_amount, created_at, fiat_currency_provision_buckets)
+    VALUES 
+        (last_bucket_id + 1, 0, 1000, now(), fiat_currency_id),
+        (last_bucket_id + 2, 1001, 5000, now(), fiat_currency_id),
+        (last_bucket_id + 3, 5001, 50000, now(), fiat_currency_id)
+    ON CONFLICT (id) DO NOTHING;
+END$$;

--- a/ent/migrate/migrations/20250117091845_zar_institutions.sql
+++ b/ent/migrate/migrations/20250117091845_zar_institutions.sql
@@ -1,0 +1,57 @@
+-- First, check if the ZAR fiat currency exists
+
+SELECT EXISTS
+    (SELECT 1
+     FROM "fiat_currencies"
+     WHERE "code" = 'ZAR' );
+
+-- If the ZAR fiat currency exists, then add the institutions
+DO $$
+DECLARE
+    fiat_currency_id UUID;
+    last_bucket_id BIGINT;
+BEGIN
+    -- Get the ID of the ZAR fiat currency
+    SELECT "id" INTO fiat_currency_id
+    FROM "fiat_currencies"
+    WHERE "code" = 'ZAR';
+
+    -- Add institutions to the ZAR fiat currency
+    WITH institutions (code, name, type, updated_at, created_at) AS (
+        VALUES
+            ('ABSAZAJJ', 'ABSA', 'bank', now(), now()),
+            ('BATHZAJJ', 'Access Bank', 'bank', now(), now()),
+            ('AFRCZAJJ', 'African Bank Limited', 'bank', now(), now()),
+            ('BWLINANX', 'Bank Eindhoek Limited', 'bank', now(), now()),
+            ('BIDBZAJJ', 'Bidvest Bank LTD', 'bank', now(), now()),
+            ('CABLZAJJ', 'Capitec Bank', 'bank', now(), now()),
+            ('DISCZAJJ', 'Discovery Bank Limited', 'bank', now(), now()),
+            ('FIRNZAJJ', 'First National Bank', 'bank', now(), now()),
+            ('MAMRZAJ1', 'Grindrod', 'bank', now(), now()),
+            ('HSBCZAJJ', 'HSBC', 'bank', now(), now()),
+            ('IVESZAJJ', 'Investec Bank', 'bank', now(), now()),
+            ('LISAZAJJ', 'Mercantile Bank', 'bank', now(), now()),
+            ('NEDSZAJJ', 'Nedbank Limited', 'bank', now(), now()),
+            ('OMIGZAJ1', 'Old Mutual Investment Group', 'bank', now(), now()),
+            ('SASFZAJJ', 'Sasfin Bank Limited', 'bank', now(), now()),
+            ('SBZAZAJJ', 'Standard Bank of South Africa Limited', 'bank', now(), now()),
+            ('MELNUS33', 'The Bank of New York Mellon', 'bank', now(), now()),
+            ('CBZAZAJJ', 'Tyme Bank', 'bank', now(), now()),
+            ('YOUBZAJJ', 'Ubank Limited', 'bank', now(), now())
+    )
+    INSERT INTO "institutions" ("code", "name", "fiat_currency_institutions", "type", "updated_at", "created_at")
+    SELECT "code", "name", fiat_currency_id, "type", "updated_at", "created_at"
+    FROM institutions
+    ON CONFLICT ("code") DO NOTHING;
+
+    -- Get the last bucket ID
+    SELECT COALESCE(MAX(id), 0) INTO last_bucket_id FROM provision_buckets;
+
+    -- Add provision buckets to the ZAR fiat currency
+    INSERT INTO provision_buckets (id, min_amount, max_amount, created_at, fiat_currency_provision_buckets)
+    VALUES
+        (last_bucket_id + 1, 0, 1000, now(), fiat_currency_id),
+        (last_bucket_id + 2, 1001, 5000, now(), fiat_currency_id),
+        (last_bucket_id + 3, 5001, 50000, now(), fiat_currency_id)
+    ON CONFLICT (id) DO NOTHING;
+END$$;

--- a/ent/migrate/migrations/20250117094130_usd_institutions.sql
+++ b/ent/migrate/migrations/20250117094130_usd_institutions.sql
@@ -1,0 +1,88 @@
+-- First, check if the USD fiat currency exists
+
+SELECT EXISTS
+    ( SELECT 1
+     FROM "fiat_currencies"
+     WHERE "code" = 'USD' );
+
+-- If the USD fiat currency exists, then add the institutions
+DO $$
+DECLARE
+    fiat_currency_id UUID;
+    last_bucket_id BIGINT;
+BEGIN
+    -- Get the ID of the USD fiat currency
+    SELECT "id" INTO fiat_currency_id
+    FROM "fiat_currencies"
+    WHERE "code" = 'USD';
+
+    -- Add institutions to the USD fiat currency
+    WITH institutions (code, name, type, updated_at, created_at) AS (
+        VALUES
+            ('ALLYUS31', 'Ally Bank', 'bank', now(), now()),
+            ('BOFAUS3N', 'Bank of America', 'bank', now(), now()),
+            ('SFRUUS33', 'Bank-Funds Federal Credit Union', 'bank', now(), now()),
+            ('BBSRUS31', 'BB&T', 'bank', now(), now()),
+            ('TCBKUSD1', 'Chase Bank', 'bank', now(), now()),
+            ('CHFGUS44', 'Choice Financial Group', 'bank', now(), now()),
+            ('CITIUS33', 'Citibank', 'bank', now(), now()),
+            ('CTZIUS33', 'Citizens Bank', 'bank', now(), now()),
+            ('CLNOUS66', 'Column NA-Brex', 'bank', now(), now()),
+            ('CMFGUS33', 'Community Federal Savings Bank', 'bank', now(), now()),
+            ('EVOVUS42', 'Evolve Bank And Trust', 'bank', now(), now()),
+            ('FHLBUS44', 'Federal Home Loan Bank', 'bank', now(), now()),
+            ('FTBCUS3C', 'Fifth Third Bank', 'bank', now(), now()),
+            ('FBERUS31', 'First Bank of Berne', 'bank', now(), now()),
+            ('FCBIUS42', 'First Citizens Bank', 'bank', now(), now()),
+            ('FRNAUS44', 'First National Bankers Bank', 'bank', now(), now()),
+            ('MRMDUS33', 'HSBC', 'bank', now(), now()),
+            ('JSBAUS41', 'Jefferson Bank', 'bank', now(), now()),
+            ('CHASUS33', 'JPMorgan Chase Bank', 'bank', now(), now()),
+            ('LIBYUS32', 'Liberty Bank', 'bank', now(), now()),
+            ('MANTUS3A', 'M&T Bank', 'bank', now(), now()),
+            ('MARQUS41', 'Marquette Bank', 'bank', now(), now()),
+            ('MCBEUS33', 'Metropolitan Commercial Bank', 'bank', now(), now()),
+            ('PNCCUS33', 'PNC Bank', 'bank', now(), now()),
+            ('HOSVUS33', 'Premier Bank', 'bank', now(), now()),
+            ('PROYUS44', 'Prosperity Bank', 'bank', now(), now()),
+            ('PRNDUS33', 'The Provident Bank', 'bank', now(), now()),
+            ('UPNBUS44', 'Regions Bank', 'bank', now(), now()),
+            ('RTCOUS33', 'Rockland Trust Company', 'bank', now(), now()),
+            ('SVBKUS6S', 'Silicon Valley Bank', 'bank', now(), now()),
+            ('SFIBUS44', 'Star Financial Bank', 'bank', now(), now()),
+            ('SNTRUS3A', 'Suntrust Bank Atlanta Los Alamit', 'bank', now(), now()),
+            ('SUWWUS6I', 'Sunwest Bank', 'bank', now(), now()),
+            ('SFGLUS31', 'Susquehanna Financial Group LLLP', 'bank', now(), now()),
+            ('SYNEUS44', 'Synergy Bank', 'bank', now(), now()),
+            ('FICOUS44', 'Synovus Bank', 'bank', now(), now()),
+            ('NRTHUS33', 'TD Bank', 'bank', now(), now()),
+            ('TENTUS44', 'Texas National Bank', 'bank', now(), now()),
+            ('IRVTUS3N', 'The Bank of New York Mellon', 'bank', now(), now()),
+            ('FMSBUS3A', 'The Farmers And Merchant State Bank', 'bank', now(), now()),
+            ('TIMNUS55', 'Timberline Bank', 'bank', now(), now()),
+            ('TRWIUS31', 'Transferwise Inc', 'bank', now(), now()),
+            ('BRBTUS33', 'Truist Bank', 'bank', now(), now()),
+            ('UMKCUS44', 'UMB Bank', 'bank', now(), now()),
+            ('USBKUS44', 'US Bank National Association', 'bank', now(), now()),
+            ('UFSBUS44', 'USAA Federal Saving Bank', 'bank', now(), now()),
+            ('MBNYUS33', 'Valley National Bank', 'bank', now(), now()),
+            ('WFBIUS6S', 'Wells Fargo Bank, N.A.', 'bank', now(), now()),
+            ('PNBPUS3W', 'Wells Fargo Clearing Services, LLC', 'bank', now(), now())
+
+    )
+    INSERT INTO "institutions" ("code", "name", "fiat_currency_institutions", "type", "updated_at", "created_at")
+    SELECT "code", "name", fiat_currency_id, "type", "updated_at", "created_at"
+    FROM institutions
+    ON CONFLICT ("code") DO NOTHING;
+
+    -- Get the last bucket ID
+    SELECT COALESCE(MAX(id), 0) INTO last_bucket_id FROM provision_buckets;
+
+    -- Add provision buckets to the USD fiat currency
+    INSERT INTO provision_buckets (id, min_amount, max_amount, created_at, fiat_currency_provision_buckets)
+    VALUES
+        (last_bucket_id + 1, 0, 1000, now(), fiat_currency_id),
+        (last_bucket_id + 2, 1001, 5000, now(), fiat_currency_id),
+        (last_bucket_id + 3, 5001, 50000, now(), fiat_currency_id)
+    ON CONFLICT (id) DO NOTHING;
+END$$;

--- a/ent/migrate/migrations/20250117095934_brl_institutions.sql
+++ b/ent/migrate/migrations/20250117095934_brl_institutions.sql
@@ -1,0 +1,80 @@
+-- First, check if the BRL fiat currency exists
+
+SELECT EXISTS
+    ( SELECT 1
+     FROM "fiat_currencies"
+     WHERE "code" = 'BRL' );
+
+-- If the BRL fiat currency exists, then add the institutions
+DO $$
+DECLARE
+    fiat_currency_id UUID;
+    last_bucket_id BIGINT;
+BEGIN
+    -- Get the ID of the BRL fiat currency
+    SELECT "id" INTO fiat_currency_id
+    FROM "fiat_currencies"
+    WHERE "code" = 'BRL';
+
+    -- Add institutions to the BRL fiat currency
+    WITH institutions (code, name, type, updated_at, created_at) AS (
+        VALUES
+            ('ABCBBRSP', 'Banco ABC Brasil S.A.', 'bank', now(), now()),
+            ('AUFABRSP', 'Banco Alfa S.A.', 'bank', now(), now()),
+            ('BMBCBRSP', 'Banco Bmg S.A.', 'bank', now(), now()),
+            ('BBONBRSP', 'Banco Bonsucesso S.A.', 'bank', now(), now()),
+            ('BBDEBRSP', 'Banco Bradesco S.A.', 'bank', now(), now()),
+            ('CSIXBRSP', 'Banco C6 S.A.', 'bank', now(), now()),
+            ('BCBZBRSP', 'Banco Cargill S.A.', 'bank', now(), now()),
+            ('CITIBRBR', 'Banco Citibank S.A.', 'bank', now(), now()),
+            ('CPBNBRDF', 'Banco Cooperativo do Brasil S.A. - BANCOOB', 'bank', now(), now()),
+            ('BCSIBRRS', 'Banco Cooperativo Sicredi S.A.', 'bank', now(), now()),
+            ('AMABBRAB', 'Banco da Amazônia S.A.', 'bank', now(), now()),
+            ('DAYCBRSP', 'Banco Daycoval S.A.', 'bank', now(), now()),
+            ('BRASBRRJ', 'Banco do Brasil S.A.', 'bank', now(), now()),
+            ('SEEBBRR1', 'Banco do Estado de Sergipe S.A.', 'bank', now(), now()),
+            ('BEPABRAB', 'Banco do Estado do Para S.A. - BANPARA', 'bank', now(), now()),
+            ('BRGSBRRS', 'Banco do Estado do Rio Grande do Sul S.A.', 'bank', now(), now()),
+            ('BNBRBRCF', 'Banco do Nordeste', 'bank', now(), now()),
+            ('BNIIBRSP', 'Banco Inbursa S.A.', 'bank', now(), now()),
+            ('ITEMBRSP', 'Banco Intermedium', 'bank', now(), now()),
+            ('BMBRBRRB', 'Banco Mercantil do Brasil S.A.', 'bank', now(), now()),
+            ('MODABRRJ', 'Banco Modal S.A.', 'bank', now(), now()),
+            ('NACDBRRJ', 'Banco Nacional de Desenvolvimento Economico e Social', 'bank', now(), now()),
+            ('BORIBRSP', 'Banco Original', 'bank', now(), now()),
+            ('BJBSBRSP', 'Banco Original do Agronegócio S.A.', 'bank', now(), now()),
+            ('BPNMBRSP', 'Banco Panamericano S.A.', 'bank', now(), now()),
+            ('SAFRBRSP', 'Banco Safra S.A.', 'bank', now(), now()),
+            ('BSCHBRSP', 'Banco Santander Brasil S.A.', 'bank', now(), now()),
+            ('BSBSBRSP', 'Banco Sofisa S.A.', 'bank', now(), now()),
+            ('BAVOBRSP', 'Banco Votorantim S.A.', 'bank', now(), now()),
+            ('BEESBRRJ', 'Banestes', 'bank', now(), now()),
+            ('BNYMBRRJ', 'Bny Mellon Banco S.A.', 'bank', now(), now()),
+            ('BRBSBRDF', 'BRB - Banco de Brasília S.A.', 'bank', now(), now()),
+            ('CEFXBRSP', 'Caixa Economica Federal - CEF', 'bank', now(), now()),
+            ('CITIBRSP', 'Citibank N.A.', 'bank', now(), now()),
+            ('HEDGBRS1', 'Credit Suisse Hedging-Griffo Corretora de Valores S.A.', 'bank', now(), now()),
+            ('GOLDBRSP', 'Goldman Sachs do Brasil Banco Múltiplo S.A.', 'bank', now(), now()),
+            ('ITAUBRSP', 'Itaú Unibanco S.A.', 'bank', now(), now()),
+            ('NUPGBRPC', 'Nu Pagamentos (Nubank)', 'bank', now(), now()),
+            ('PSITBRPC', 'PagSeguro Internet S.A.', 'bank', now(), now()),
+            ('BCIIBRSP', 'State Street Brazil S.A.', 'bank', now(), now()),
+            ('LICTBRS1', 'UBS Brazil Corretora de Câmbio, Títulos e Valores Mobiliários S.A.', 'bank', now(), now())
+
+    )
+    INSERT INTO "institutions" ("code", "name", "fiat_currency_institutions", "type", "updated_at", "created_at")
+    SELECT "code", "name", fiat_currency_id, "type", "updated_at", "created_at"
+    FROM institutions
+    ON CONFLICT ("code") DO NOTHING;
+
+    -- Get the last bucket ID
+    SELECT COALESCE(MAX(id), 0) INTO last_bucket_id FROM provision_buckets;
+
+    -- Add provision buckets to the BRL fiat currency
+    INSERT INTO provision_buckets (id, min_amount, max_amount, created_at, fiat_currency_provision_buckets)
+    VALUES
+        (last_bucket_id + 1, 0, 1000, now(), fiat_currency_id),
+        (last_bucket_id + 2, 1001, 5000, now(), fiat_currency_id),
+        (last_bucket_id + 3, 5001, 50000, now(), fiat_currency_id)
+    ON CONFLICT (id) DO NOTHING;
+END$$;


### PR DESCRIPTION
Add support for BRL, USD, ZAR, and INR currencies along with their respective financial institutions to expand Paycrest's supported payment networks.

closes https://github.com/paycrest/protocol/pull/388