### PR TITLE
Validate institution existence in payment order initiation

### DIFF
--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -56,26 +56,6 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 		return
 	}
 
-	// Validate if institution exists
-	institutionExists, err := storage.Client.Institution.
-		Query().
-		Where(
-			institution.CodeEQ(payload.Recipient.Institution),
-		).
-		Exist(ctx)
-	if err != nil {
-		logger.Errorf("error validating institution: %v", err)
-		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to validate institution", nil)
-		return
-	}
-	if !institutionExists {
-		u.APIResponse(ctx, http.StatusBadRequest, "error", "Failed to validate payload", types.ErrorData{
-			Field:   "Institution",
-			Message: "Invalid institution code provided",
-		})
-		return
-	}
-
 	// Get sender profile from the context
 	senderCtx, ok := ctx.Get("sender")
 	if !ok {
@@ -227,6 +207,26 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 			})
 			return
 		}
+	}
+
+	// Validate if institution exists
+	institutionExists, err := storage.Client.Institution.
+		Query().
+		Where(
+			institution.CodeEQ(payload.Recipient.Institution),
+		).
+		Exist(ctx)
+	if err != nil {
+		logger.Errorf("error validating institution: %v", err)
+		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to validate institution", nil)
+		return
+	}
+	if !institutionExists {
+		u.APIResponse(ctx, http.StatusBadRequest, "error", "Failed to validate payload", types.ErrorData{
+			Field:   "Recipient",
+			Message: "Invalid institution code provided",
+		})
+		return
 	}
 
 	isPrivate := false


### PR DESCRIPTION
What does this PR do?
* Adds validation to check if the recipient's institution code exists in the database before proceeding with the payment order creation.


Why is this needed?
* To prevent the creation of payment orders with invalid institution codes.

* Improves error handling by providing early validation

* Prevents unnecessary processing and potential downstream issues caused by invalid data.


